### PR TITLE
Add coroutine to get bookmark dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,25 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Get Bookmark Dates
+
+To get a summary of dates and how many bookmarks were created on those dates:
+
+```python
+import asyncio
+
+from aiopinboard import Client
+
+
+async def main() -> None:
+    api = API("<PINBOARD_API_TOKEN>")
+    dates = await api.async_get_dates()
+    # >>> {datetime.date(2020, 09, 05): 4, ...}
+
+
+asyncio.run(main())
+```
+
 # Contributing
 
 1. [Check for open features/bugs](https://github.com/bachya/aiopinboard/issues)

--- a/tests/fixtures/posts_dates_response.xml
+++ b/tests/fixtures/posts_dates_response.xml
@@ -1,0 +1,5 @@
+<dates user="auser" tag="tag1 tag2">
+  <date count="1" date="2020-09-05"/>
+  <date count="1" date="2020-09-04"/>
+  <date count="3" date="2020-09-03"/>
+</dates>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 
 from aiohttp import ClientSession
+import maya
 import pytest
 import pytz
 
@@ -133,6 +134,27 @@ async def test_get_bookmarks_by_date(aresponses):
             pytz.utc.localize(datetime(2020, 9, 3, 13, 7, 19)), tags=["non-tag1"]
         )
         assert not bookmarks
+
+
+@pytest.mark.asyncio
+async def test_get_dates(aresponses):
+    """Test getting bookmarks by date."""
+    aresponses.add(
+        "api.pinboard.in",
+        "/v1/posts/dates",
+        "get",
+        aresponses.Response(text=load_fixture("posts_dates_response.xml"), status=200),
+    )
+
+    async with ClientSession() as session:
+        api = API(TEST_API_TOKEN, session=session)
+
+        dates = await api.async_get_dates(tags=["tag1", "tag2"])
+        assert dates == {
+            maya.parse("2020-09-05").datetime().date(): 1,
+            maya.parse("2020-09-04").datetime().date(): 1,
+            maya.parse("2020-09-03").datetime().date(): 3,
+        }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a new coroutine to retrieve a mapping of dates and how many bookmarks were created on those dates:

* `API.async_get_dates()`: correlates to https://pinboard.in/api#posts_dates

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
