### PR TITLE
Add coroutine to get recent bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,30 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Get Recent Bookmarks
+
+To get recent bookmarks:
+
+```python
+import asyncio
+
+from aiopinboard import Client
+
+
+async def main() -> None:
+    api = API("<PINBOARD_API_TOKEN>")
+    await api.async_get_recent_bookmarks(count=10)
+    # >>> [<Bookmark ...>, <Bookmark ...>]
+
+    # Optionally filter the results with a list of tags – note that only bookmarks that
+    # have all tags will be returned:
+    await api.async_get_bookmarks_by_date(count=20, tags=["tag1", "tag2"])
+    # >>> [<Bookmark ...>, <Bookmark ...>]
+
+
+asyncio.run(main())
+```
+
 ## Adding a Bookmark
 
 To add a bookmark:

--- a/aiopinboard/api.py
+++ b/aiopinboard/api.py
@@ -15,6 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 API_URL_BASE: str = "https://api.pinboard.in/v1"
 
+DEFAULT_RECENT_BOOKMARKS_COUNT: int = 15
 DEFAULT_TIMEOUT: int = 10
 
 
@@ -201,3 +202,25 @@ class API:
         resp = await self._async_request("get", "posts/update")
         maya_dt = maya.parse(resp.attrib["time"])
         return maya_dt.datetime()
+
+    async def async_get_recent_bookmarks(
+        self,
+        *,
+        count: int = DEFAULT_RECENT_BOOKMARKS_COUNT,
+        tags: Optional[List[str]] = None,
+    ) -> List[Bookmark]:
+        """Get recent bookmarks.
+
+        :param count: The number of bookmarks to return (max of 100)
+        :type count: ``int``
+        :param tags: An optional list of tags to filter results by
+        :type tags: ``Optional[List[str]]``
+        :rtype: ``List[Bookmark]``
+        """
+        params: Dict[str, Any] = {"count": count}
+
+        if tags:
+            params["tags"] = " ".join([str(tag) for tag in tags])
+
+        resp = await self._async_request("get", "posts/recent", params=params)
+        return [async_create_bookmark_from_xml(bookmark) for bookmark in resp]

--- a/tests/fixtures/posts_recent_response.xml
+++ b/tests/fixtures/posts_recent_response.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<posts user="auser" dt="2020-09-02T03:43:26Z">
+    <post href="https://mylink.com" time="2020-09-02t03:59:55z" description="A really neat website!" extended="I saved this bookmark to Pinboard" tag="tag1 tag2" hash="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"  shared="no" toread="yes" />
+</posts>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -191,3 +191,30 @@ async def test_get_last_change_datetime_no_session(aresponses):
     most_recent_dt = await api.async_get_last_change_datetime()
 
     assert most_recent_dt == pytz.utc.localize(datetime(2020, 9, 3, 13, 7, 19))
+
+
+@pytest.mark.asyncio
+async def test_get_recent_bookmarks(aresponses):
+    """Test getting recent bookmarks."""
+    aresponses.add(
+        "api.pinboard.in",
+        "/v1/posts/recent",
+        "get",
+        aresponses.Response(text=load_fixture("posts_recent_response.xml"), status=200),
+    )
+
+    async with ClientSession() as session:
+        api = API(TEST_API_TOKEN, session=session)
+
+        bookmarks = await api.async_get_recent_bookmarks(count=1, tags=["tag1"])
+        assert len(bookmarks) == 1
+        assert bookmarks[0] == Bookmark(
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "https://mylink.com",
+            "A really neat website!",
+            "I saved this bookmark to Pinboard",
+            pytz.utc.localize(datetime(2020, 9, 2, 3, 59, 55)),
+            tags=["tag1", "tag2"],
+            unread=True,
+            shared=False,
+        )


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a new coroutine to retrieve recent bookmarks:

* `API.async_get_recent_bookmarks(...)`: correlates to https://pinboard.in/api#posts_recent

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
