### PR TITLE
Add coroutine to get suggested tags for a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,26 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Getting Suggested Tags
+
+To get lists of popular (used by the community) and recommended (used by you) tags for a
+particular URL:
+
+```python
+import asyncio
+
+from aiopinboard import Client
+
+
+async def main() -> None:
+    api = API("<PINBOARD_API_TOKEN>")
+    await api.async_get_suggested_tags("https://my.com/bookmark")
+    # >>> {"popular": ["tag1", "tag2"], "recommended": ["tag3"]}
+
+
+asyncio.run(main())
+```
+
 # Contributing
 
 1. [Check for open features/bugs](https://github.com/bachya/aiopinboard/issues)

--- a/aiopinboard/api.py
+++ b/aiopinboard/api.py
@@ -272,8 +272,7 @@ class API:
 
         resp = await self._async_request("get", "posts/suggest", params={"url": url})
         for tag in resp:
-            if tag.text in data[tag.tag]:
-                continue
-            data[tag.tag].append(tag.text)
+            if tag.text not in data[tag.tag]:
+                data[tag.tag].append(tag.text)
 
         return data

--- a/aiopinboard/api.py
+++ b/aiopinboard/api.py
@@ -261,3 +261,19 @@ class API:
 
         resp = await self._async_request("get", "posts/recent", params=params)
         return [async_create_bookmark_from_xml(bookmark) for bookmark in resp]
+
+    async def async_get_suggested_tags(self, url: str) -> Dict[str, List[str]]:
+        """Return a dictionary of popular and recommended tags for a URL.
+
+        :param url: The URL of the bookmark to delete
+        :type url: ``str``
+        """
+        data: Dict[str, List[str]] = {"popular": [], "recommended": []}
+
+        resp = await self._async_request("get", "posts/suggest", params={"url": url})
+        for tag in resp:
+            if tag.text in data[tag.tag]:
+                continue
+            data[tag.tag].append(tag.text)
+
+        return data

--- a/tests/fixtures/posts_dates_response.xml
+++ b/tests/fixtures/posts_dates_response.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <dates user="auser" tag="tag1 tag2">
   <date count="1" date="2020-09-05"/>
   <date count="1" date="2020-09-04"/>

--- a/tests/fixtures/posts_suggest_response.xml
+++ b/tests/fixtures/posts_suggest_response.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<suggested>
+  <popular>security</popular>
+  <popular>security</popular>
+  <recommended>ssh</recommended>
+  <recommended>linux</recommended>
+</suggested>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -251,3 +251,25 @@ async def test_get_recent_bookmarks(aresponses):
             unread=True,
             shared=False,
         )
+
+
+@pytest.mark.asyncio
+async def test_get_suggested_tags(aresponses):
+    """Test getting recent bookmarks."""
+    aresponses.add(
+        "api.pinboard.in",
+        "/v1/posts/suggest",
+        "get",
+        aresponses.Response(
+            text=load_fixture("posts_suggest_response.xml"), status=200
+        ),
+    )
+
+    async with ClientSession() as session:
+        api = API(TEST_API_TOKEN, session=session)
+
+        tags = await api.async_get_suggested_tags("https://mylink.com")
+        assert tags == {
+            "popular": ["security"],
+            "recommended": ["ssh", "linux"],
+        }


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a new coroutine to get suggested tags for a URL:

* `API.async_get_suggested_tags(url)`: correlates to https://pinboard.in/api#posts_suggest

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
