### PR TITLE
Move bookmark API endpoints to their own object

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ from aiopinboard import Client
 
 async def main() -> None:
     api = API("<PINBOARD_API_TOKEN>")
-    await api.async_get_bookmark_by_url("https://my.com/bookmark")
+    await api.bookmark.async_get_bookmark_by_url("https://my.com/bookmark")
     # >>> <Bookmark href="https://my.com/bookmark">
 
 
@@ -122,7 +122,7 @@ from aiopinboard import Client
 
 async def main() -> None:
     api = API("<PINBOARD_API_TOKEN>")
-    await api.async_get_all_bookmarks()
+    await api.bookmark.async_get_all_bookmarks()
     # >>> [<Bookmark ...>, <Bookmark ...>]
 
 
@@ -148,12 +148,12 @@ from aiopinboard import Client
 
 async def main() -> None:
     api = API("<PINBOARD_API_TOKEN>")
-    await api.async_get_bookmarks_by_date(date.today())
+    await api.bookmark.async_get_bookmarks_by_date(date.today())
     # >>> [<Bookmark ...>, <Bookmark ...>]
 
     # Optionally filter the results with a list of tags – note that only bookmarks that
     # have all tags will be returned:
-    await api.async_get_bookmarks_by_date(date.today(), tags=["tag1", "tag2"])
+    await api.bookmark.async_get_bookmarks_by_date(date.today(), tags=["tag1", "tag2"])
     # >>> [<Bookmark ...>, <Bookmark ...>]
 )
 
@@ -171,12 +171,12 @@ from aiopinboard import Client
 
 async def main() -> None:
     api = API("<PINBOARD_API_TOKEN>")
-    await api.async_get_recent_bookmarks(count=10)
+    await api.bookmark.async_get_recent_bookmarks(count=10)
     # >>> [<Bookmark ...>, <Bookmark ...>]
 
     # Optionally filter the results with a list of tags – note that only bookmarks that
     # have all tags will be returned:
-    await api.async_get_recent_bookmarks(count=20, tags=["tag1", "tag2"])
+    await api.bookmark.async_get_recent_bookmarks(count=20, tags=["tag1", "tag2"])
     # >>> [<Bookmark ...>, <Bookmark ...>]
 
 
@@ -193,7 +193,7 @@ from aiopinboard import Client
 
 async def main() -> None:
     api = API("<PINBOARD_API_TOKEN>")
-    dates = await api.async_get_dates()
+    dates = await api.bookmark.async_get_dates()
     # >>> {datetime.date(2020, 09, 05): 4, ...}
 
 
@@ -211,7 +211,7 @@ from aiopinboard import Client
 
 async def main() -> None:
     api = API("<PINBOARD_API_TOKEN>")
-    await api.async_add_bookmark("https://my.com/bookmark", "My New Bookmark")
+    await api.bookmark.async_add_bookmark("https://my.com/bookmark", "My New Bookmark")
 
 
 asyncio.run(main())
@@ -238,7 +238,7 @@ from aiopinboard import Client
 
 async def main() -> None:
     api = API("<PINBOARD_API_TOKEN>")
-    await api.async_delete_bookmark("https://my.com/bookmark")
+    await api.bookmark.async_delete_bookmark("https://my.com/bookmark")
 
 
 asyncio.run(main())
@@ -257,7 +257,7 @@ from aiopinboard import Client
 
 async def main() -> None:
     api = API("<PINBOARD_API_TOKEN>")
-    await api.async_get_suggested_tags("https://my.com/bookmark")
+    await api.bookmark.async_get_suggested_tags("https://my.com/bookmark")
     # >>> {"popular": ["tag1", "tag2"], "recommended": ["tag3"]}
 
 

--- a/aiopinboard/api.py
+++ b/aiopinboard/api.py
@@ -1,44 +1,22 @@
 """Define an API object to interact with the Pinboard API."""
-from datetime import date, datetime
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 from aiohttp import ClientSession, ClientTimeout
 from aiohttp.client_exceptions import ClientError
 from defusedxml import ElementTree
-import maya
 
+from aiopinboard.bookmark import BookmarkAPI
 from aiopinboard.errors import RequestError, raise_on_response_error
-from aiopinboard.helpers.bookmark import Bookmark
 
 _LOGGER = logging.getLogger(__name__)
 
 API_URL_BASE: str = "https://api.pinboard.in/v1"
 
-DEFAULT_RECENT_BOOKMARKS_COUNT: int = 15
 DEFAULT_TIMEOUT: int = 10
 
 
-def async_create_bookmark_from_xml(tree: ElementTree) -> Bookmark:
-    """Create a bookmark from an XML response.
-
-    :param tree: The XML element tree to parse
-    :type tree: ``ElementTree``
-    :rtype: ``Bookmark``
-    """
-    return Bookmark(
-        tree.attrib["hash"],
-        tree.attrib["href"],
-        tree.attrib["description"],
-        tree.attrib["extended"],
-        maya.parse(tree.attrib["time"]).datetime(),
-        tree.attrib["tag"].split(),
-        tree.attrib.get("toread") == "yes",
-        tree.attrib.get("shared") == "yes",
-    )
-
-
-class API:
+class API:  # pylint: disable=too-few-public-methods
     """Define an API object.
 
     :param api_token: A Pinboard API token
@@ -53,6 +31,8 @@ class API:
         """Initialize."""
         self._api_token = api_token
         self._session: ClientSession = session
+
+        self.bookmark = BookmarkAPI(self._async_request)
 
     async def _async_request(self, method: str, endpoint: str, **kwargs) -> ElementTree:
         """Make a request to the API and return the XML response."""
@@ -84,195 +64,3 @@ class API:
         finally:
             if not use_running_session:
                 await session.close()
-
-    async def async_add_bookmark(
-        self,
-        url: str,
-        title: str,
-        *,
-        description: Optional[str] = None,
-        tags: Optional[List[str]] = None,
-        created_datetime: Optional[datetime] = None,
-        replace: bool = True,
-        shared: bool = False,
-        toread: bool = False,
-    ) -> None:
-        """Add a new bookmark.
-
-        :param url: The URL of the bookmark
-        :type url: ``str``
-        :param title: The title of the bookmark
-        :type title: ``str``
-        :param description: The optional description of the bookmark
-        :type description: ``Optional[str]``
-        :param tags: An optional list of tags to assign to the bookmark
-        :type tags: ``Optional[List[str]]``
-        :param created_datetime: The optional creation datetime to use (defaults to now)
-        :type created_datetime: ``Optional[datetime]``
-        :param replace: Whether this should replace a bookmark with the same URL
-        :type replace: ``bool``
-        :param shared: Whether this bookmark should be shared
-        :type shared: ``bool``
-        :param toread: Whether this bookmark should be unread
-        :type toread: ``bool``
-        :rtype: ``Bookmark``
-        """
-        params: Dict[str, Any] = {"url": url, "description": title}
-
-        if description:
-            params["description"] = description
-        if tags:
-            params["tags"] = tags
-        if created_datetime:
-            params["dt"] = created_datetime.isoformat()
-
-        params["replace"] = "yes" if replace else "no"
-        params["shared"] = "yes" if shared else "no"
-        params["toread"] = "yes" if toread else "no"
-
-        await self._async_request("get", "posts/add", params=params)
-
-    async def async_delete_bookmark(self, url: str) -> None:
-        """Delete a bookmark by URL.
-
-        :param url: The URL of the bookmark to delete
-        :type url: ``str``
-        """
-        await self._async_request("get", "posts/delete", params={"url": url})
-
-    async def async_get_all_bookmarks(
-        self,
-        *,
-        tags: Optional[List[str]] = None,
-        start: int = 0,
-        results: Optional[int] = None,
-        from_dt: Optional[datetime] = None,
-        to_dt: Optional[datetime] = None,
-    ) -> List[Bookmark]:
-        """Get recent bookmarks.
-
-        :param tags: An optional list of tags to filter results by
-        :type tags: ``Optional[List[str]]``
-        :param start: The optional starting index to return (defaults to the start)
-        :type start: ``int``
-        :param results: The optional number of results (defaults to all)
-        :type results: ``int``
-        :param from_dt: The optional datetime to start from
-        :type from_dt: ``Optional[datetime]``
-        :param to_dt: The optional datetime to end at
-        :type to_dt: ``Optional[datetime]``
-        :rtype: ``List[Bookmark]``
-        """
-        params: Dict[str, Any] = {"start": start}
-
-        if tags:
-            params["tags"] = " ".join([str(tag) for tag in tags])
-        if results:
-            params["results"] = results
-        if from_dt:
-            params["fromdt"] = from_dt.isoformat()
-        if to_dt:
-            params["fromdt"] = to_dt.isoformat()
-
-        resp = await self._async_request("get", "posts/all", params=params)
-        return [async_create_bookmark_from_xml(bookmark) for bookmark in resp]
-
-    async def async_get_bookmark_by_url(self, url: str) -> Optional[Bookmark]:
-        """Get bookmark by a URL. Returns None if no bookmark exists for URL.
-
-        :param url: The URL of the bookmark to get
-        :type url: ``Optional[Bookmark]``
-        :rtype: ``Optional[Bookmark]``
-        """
-        resp = await self._async_request("get", "posts/get", params={"url": url})
-
-        try:
-            return async_create_bookmark_from_xml(resp[0])
-        except IndexError:
-            return None
-
-    async def async_get_bookmarks_by_date(
-        self, bookmarked_on: date, *, tags: Optional[List[str]] = None
-    ) -> List[Bookmark]:
-        """Get bookmarks that were created on a specific date.
-
-        :param bookmarked_on: The date to examine
-        :type bookmarked_on: ``date``
-        :param tags: An optional list of tags to filter results by
-        :type tags: ``Optional[List[str]]``
-        :rtype: ``List[Bookmark]``
-        """
-        params: Dict[str, Any] = {"dt": str(bookmarked_on)}
-
-        if tags:
-            params["tags"] = " ".join([str(tag) for tag in tags])
-
-        resp = await self._async_request("get", "posts/get", params=params)
-        return [async_create_bookmark_from_xml(bookmark) for bookmark in resp]
-
-    async def async_get_dates(
-        self, *, tags: Optional[List[str]] = None
-    ) -> Dict[date, int]:
-        """Get a dictionary of dates and the number of bookmarks created on that date.
-
-        :param tags: An optional list of tags to filter results by
-        :type tags: ``Optional[List[str]]``
-        :rtype: ``Dict[date, int]``
-        """
-        params: Dict[str, Any] = {}
-
-        if tags:
-            params["tags"] = " ".join([str(tag) for tag in tags])
-
-        resp = await self._async_request("get", "posts/dates")
-
-        return {
-            maya.parse(row.attrib["date"]).datetime().date(): int(row.attrib["count"])
-            for row in resp
-        }
-
-    async def async_get_last_change_datetime(self) -> datetime:
-        """Return the most recent time a bookmark was added, updated or deleted.
-
-        :rtype: ``datetime``
-        """
-        resp = await self._async_request("get", "posts/update")
-        maya_dt = maya.parse(resp.attrib["time"])
-        return maya_dt.datetime()
-
-    async def async_get_recent_bookmarks(
-        self,
-        *,
-        count: int = DEFAULT_RECENT_BOOKMARKS_COUNT,
-        tags: Optional[List[str]] = None,
-    ) -> List[Bookmark]:
-        """Get recent bookmarks.
-
-        :param count: The number of bookmarks to return (max of 100)
-        :type count: ``int``
-        :param tags: An optional list of tags to filter results by
-        :type tags: ``Optional[List[str]]``
-        :rtype: ``List[Bookmark]``
-        """
-        params: Dict[str, Any] = {"count": count}
-
-        if tags:
-            params["tags"] = " ".join([str(tag) for tag in tags])
-
-        resp = await self._async_request("get", "posts/recent", params=params)
-        return [async_create_bookmark_from_xml(bookmark) for bookmark in resp]
-
-    async def async_get_suggested_tags(self, url: str) -> Dict[str, List[str]]:
-        """Return a dictionary of popular and recommended tags for a URL.
-
-        :param url: The URL of the bookmark to delete
-        :type url: ``str``
-        """
-        data: Dict[str, List[str]] = {"popular": [], "recommended": []}
-
-        resp = await self._async_request("get", "posts/suggest", params={"url": url})
-        for tag in resp:
-            if tag.text not in data[tag.tag]:
-                data[tag.tag].append(tag.text)
-
-        return data

--- a/aiopinboard/bookmark.py
+++ b/aiopinboard/bookmark.py
@@ -1,0 +1,229 @@
+"""Define API endpoints for bookmarks."""
+from datetime import date, datetime
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from defusedxml import ElementTree
+import maya
+
+from aiopinboard.helpers.bookmark import Bookmark
+
+DEFAULT_RECENT_BOOKMARKS_COUNT: int = 15
+
+
+def async_create_bookmark_from_xml(tree: ElementTree) -> Bookmark:
+    """Create a bookmark from an XML response.
+
+    :param tree: The XML element tree to parse
+    :type tree: ``ElementTree``
+    :rtype: ``Bookmark``
+    """
+    return Bookmark(
+        tree.attrib["hash"],
+        tree.attrib["href"],
+        tree.attrib["description"],
+        tree.attrib["extended"],
+        maya.parse(tree.attrib["time"]).datetime(),
+        tree.attrib["tag"].split(),
+        tree.attrib.get("toread") == "yes",
+        tree.attrib.get("shared") == "yes",
+    )
+
+
+class BookmarkAPI:
+    """Define an API "manager" object."""
+
+    def __init__(self, async_request: Callable[..., Awaitable]) -> None:
+        """Initialize."""
+        self._async_request = async_request
+
+    async def async_add_bookmark(
+        self,
+        url: str,
+        title: str,
+        *,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        created_datetime: Optional[datetime] = None,
+        replace: bool = True,
+        shared: bool = False,
+        toread: bool = False,
+    ) -> None:
+        """Add a new bookmark.
+
+        :param url: The URL of the bookmark
+        :type url: ``str``
+        :param title: The title of the bookmark
+        :type title: ``str``
+        :param description: The optional description of the bookmark
+        :type description: ``Optional[str]``
+        :param tags: An optional list of tags to assign to the bookmark
+        :type tags: ``Optional[List[str]]``
+        :param created_datetime: The optional creation datetime to use (defaults to now)
+        :type created_datetime: ``Optional[datetime]``
+        :param replace: Whether this should replace a bookmark with the same URL
+        :type replace: ``bool``
+        :param shared: Whether this bookmark should be shared
+        :type shared: ``bool``
+        :param toread: Whether this bookmark should be unread
+        :type toread: ``bool``
+        :rtype: ``Bookmark``
+        """
+        params: Dict[str, Any] = {"url": url, "description": title}
+
+        if description:
+            params["description"] = description
+        if tags:
+            params["tags"] = tags
+        if created_datetime:
+            params["dt"] = created_datetime.isoformat()
+
+        params["replace"] = "yes" if replace else "no"
+        params["shared"] = "yes" if shared else "no"
+        params["toread"] = "yes" if toread else "no"
+
+        await self._async_request("get", "posts/add", params=params)
+
+    async def async_delete_bookmark(self, url: str) -> None:
+        """Delete a bookmark by URL.
+
+        :param url: The URL of the bookmark to delete
+        :type url: ``str``
+        """
+        await self._async_request("get", "posts/delete", params={"url": url})
+
+    async def async_get_all_bookmarks(
+        self,
+        *,
+        tags: Optional[List[str]] = None,
+        start: int = 0,
+        results: Optional[int] = None,
+        from_dt: Optional[datetime] = None,
+        to_dt: Optional[datetime] = None,
+    ) -> List[Bookmark]:
+        """Get recent bookmarks.
+
+        :param tags: An optional list of tags to filter results by
+        :type tags: ``Optional[List[str]]``
+        :param start: The optional starting index to return (defaults to the start)
+        :type start: ``int``
+        :param results: The optional number of results (defaults to all)
+        :type results: ``int``
+        :param from_dt: The optional datetime to start from
+        :type from_dt: ``Optional[datetime]``
+        :param to_dt: The optional datetime to end at
+        :type to_dt: ``Optional[datetime]``
+        :rtype: ``List[Bookmark]``
+        """
+        params: Dict[str, Any] = {"start": start}
+
+        if tags:
+            params["tags"] = " ".join([str(tag) for tag in tags])
+        if results:
+            params["results"] = results
+        if from_dt:
+            params["fromdt"] = from_dt.isoformat()
+        if to_dt:
+            params["fromdt"] = to_dt.isoformat()
+
+        resp = await self._async_request("get", "posts/all", params=params)
+        return [async_create_bookmark_from_xml(bookmark) for bookmark in resp]
+
+    async def async_get_bookmark_by_url(self, url: str) -> Optional[Bookmark]:
+        """Get bookmark by a URL. Returns None if no bookmark exists for URL.
+
+        :param url: The URL of the bookmark to get
+        :type url: ``Optional[Bookmark]``
+        :rtype: ``Optional[Bookmark]``
+        """
+        resp = await self._async_request("get", "posts/get", params={"url": url})
+
+        try:
+            return async_create_bookmark_from_xml(resp[0])
+        except IndexError:
+            return None
+
+    async def async_get_bookmarks_by_date(
+        self, bookmarked_on: date, *, tags: Optional[List[str]] = None
+    ) -> List[Bookmark]:
+        """Get bookmarks that were created on a specific date.
+
+        :param bookmarked_on: The date to examine
+        :type bookmarked_on: ``date``
+        :param tags: An optional list of tags to filter results by
+        :type tags: ``Optional[List[str]]``
+        :rtype: ``List[Bookmark]``
+        """
+        params: Dict[str, Any] = {"dt": str(bookmarked_on)}
+
+        if tags:
+            params["tags"] = " ".join([str(tag) for tag in tags])
+
+        resp = await self._async_request("get", "posts/get", params=params)
+        return [async_create_bookmark_from_xml(bookmark) for bookmark in resp]
+
+    async def async_get_dates(
+        self, *, tags: Optional[List[str]] = None
+    ) -> Dict[date, int]:
+        """Get a dictionary of dates and the number of bookmarks created on that date.
+
+        :param tags: An optional list of tags to filter results by
+        :type tags: ``Optional[List[str]]``
+        :rtype: ``Dict[date, int]``
+        """
+        params: Dict[str, Any] = {}
+
+        if tags:
+            params["tags"] = " ".join([str(tag) for tag in tags])
+
+        resp = await self._async_request("get", "posts/dates")
+
+        return {
+            maya.parse(row.attrib["date"]).datetime().date(): int(row.attrib["count"])
+            for row in resp
+        }
+
+    async def async_get_last_change_datetime(self) -> datetime:
+        """Return the most recent time a bookmark was added, updated or deleted.
+
+        :rtype: ``datetime``
+        """
+        resp = await self._async_request("get", "posts/update")
+        maya_dt = maya.parse(resp.attrib["time"])
+        return maya_dt.datetime()
+
+    async def async_get_recent_bookmarks(
+        self,
+        *,
+        count: int = DEFAULT_RECENT_BOOKMARKS_COUNT,
+        tags: Optional[List[str]] = None,
+    ) -> List[Bookmark]:
+        """Get recent bookmarks.
+
+        :param count: The number of bookmarks to return (max of 100)
+        :type count: ``int``
+        :param tags: An optional list of tags to filter results by
+        :type tags: ``Optional[List[str]]``
+        :rtype: ``List[Bookmark]``
+        """
+        params: Dict[str, Any] = {"count": count}
+
+        if tags:
+            params["tags"] = " ".join([str(tag) for tag in tags])
+
+        resp = await self._async_request("get", "posts/recent", params=params)
+        return [async_create_bookmark_from_xml(bookmark) for bookmark in resp]
+
+    async def async_get_suggested_tags(self, url: str) -> Dict[str, List[str]]:
+        """Return a dictionary of popular and recommended tags for a URL.
+
+        :param url: The URL of the bookmark to delete
+        :type url: ``str``
+        """
+        data: Dict[str, List[str]] = {"popular": [], "recommended": []}
+
+        resp = await self._async_request("get", "posts/suggest", params={"url": url})
+        for tag in resp:
+            if tag.text not in data[tag.tag]:
+                data[tag.tag].append(tag.text)
+
+        return data

--- a/tests/test_bookmark_api.py
+++ b/tests/test_bookmark_api.py
@@ -27,7 +27,7 @@ async def test_add_bookmark(aresponses):
 
         # A unsuccessful request will throw an exception, so if no exception is thrown,
         # we can count this as a successful test:
-        await api.async_add_bookmark(
+        await api.bookmark.async_add_bookmark(
             "http://test.url",
             "My Test Bookmark",
             description="I like this bookmark",
@@ -54,7 +54,7 @@ async def test_delete_bookmark(aresponses):
 
         # A unsuccessful request will throw an exception, so if no exception is thrown,
         # we can count this as a successful test:
-        await api.async_delete_bookmark("http://test.url")
+        await api.bookmark.async_delete_bookmark("http://test.url")
 
 
 @pytest.mark.asyncio
@@ -70,7 +70,7 @@ async def test_get_all_bookmarks(aresponses):
     async with ClientSession() as session:
         api = API(TEST_API_TOKEN, session=session)
 
-        bookmarks = await api.async_get_all_bookmarks(
+        bookmarks = await api.bookmark.async_get_all_bookmarks(
             tags=["tag1"],
             start=2,
             results=1,
@@ -111,7 +111,7 @@ async def test_get_bookmark_by_url(aresponses):
     async with ClientSession() as session:
         api = API(TEST_API_TOKEN, session=session)
 
-        bookmark = await api.async_get_bookmark_by_url("https://mylink.com")
+        bookmark = await api.bookmark.async_get_bookmark_by_url("https://mylink.com")
         assert bookmark == Bookmark(
             "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             "https://mylink.com",
@@ -123,7 +123,9 @@ async def test_get_bookmark_by_url(aresponses):
             shared=False,
         )
 
-        bookmark = await api.async_get_bookmark_by_url("https://doesntexist.com")
+        bookmark = await api.bookmark.async_get_bookmark_by_url(
+            "https://doesntexist.com"
+        )
         assert not bookmark
 
 
@@ -148,7 +150,7 @@ async def test_get_bookmarks_by_date(aresponses):
     async with ClientSession() as session:
         api = API(TEST_API_TOKEN, session=session)
 
-        bookmarks = await api.async_get_bookmarks_by_date(
+        bookmarks = await api.bookmark.async_get_bookmarks_by_date(
             pytz.utc.localize(datetime(2020, 9, 3, 13, 7, 19))
         )
         assert len(bookmarks) == 1
@@ -163,7 +165,7 @@ async def test_get_bookmarks_by_date(aresponses):
             shared=False,
         )
 
-        bookmarks = await api.async_get_bookmarks_by_date(
+        bookmarks = await api.bookmark.async_get_bookmarks_by_date(
             pytz.utc.localize(datetime(2020, 9, 3, 13, 7, 19)), tags=["non-tag1"]
         )
         assert not bookmarks
@@ -182,7 +184,7 @@ async def test_get_dates(aresponses):
     async with ClientSession() as session:
         api = API(TEST_API_TOKEN, session=session)
 
-        dates = await api.async_get_dates(tags=["tag1", "tag2"])
+        dates = await api.bookmark.async_get_dates(tags=["tag1", "tag2"])
         assert dates == {
             maya.parse("2020-09-05").datetime().date(): 1,
             maya.parse("2020-09-04").datetime().date(): 1,
@@ -202,7 +204,7 @@ async def test_get_last_change_datetime(aresponses):
 
     async with ClientSession() as session:
         api = API(TEST_API_TOKEN, session=session)
-        most_recent_dt = await api.async_get_last_change_datetime()
+        most_recent_dt = await api.bookmark.async_get_last_change_datetime()
 
         assert most_recent_dt == pytz.utc.localize(datetime(2020, 9, 3, 13, 7, 19))
 
@@ -221,7 +223,7 @@ async def test_get_last_change_datetime_no_session(aresponses):
     )
 
     api = API(TEST_API_TOKEN)
-    most_recent_dt = await api.async_get_last_change_datetime()
+    most_recent_dt = await api.bookmark.async_get_last_change_datetime()
 
     assert most_recent_dt == pytz.utc.localize(datetime(2020, 9, 3, 13, 7, 19))
 
@@ -239,7 +241,9 @@ async def test_get_recent_bookmarks(aresponses):
     async with ClientSession() as session:
         api = API(TEST_API_TOKEN, session=session)
 
-        bookmarks = await api.async_get_recent_bookmarks(count=1, tags=["tag1"])
+        bookmarks = await api.bookmark.async_get_recent_bookmarks(
+            count=1, tags=["tag1"]
+        )
         assert len(bookmarks) == 1
         assert bookmarks[0] == Bookmark(
             "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -268,7 +272,7 @@ async def test_get_suggested_tags(aresponses):
     async with ClientSession() as session:
         api = API(TEST_API_TOKEN, session=session)
 
-        tags = await api.async_get_suggested_tags("https://mylink.com")
+        tags = await api.bookmark.async_get_suggested_tags("https://mylink.com")
         assert tags == {
             "popular": ["security"],
             "recommended": ["ssh", "linux"],

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -21,7 +21,7 @@ async def test_data_error(aresponses):
     async with ClientSession() as session:
         api = API(TEST_API_TOKEN, session=session)
         with pytest.raises(RequestError) as err:
-            await api.async_delete_bookmark("http://test.url")
+            await api.bookmark.async_delete_bookmark("http://test.url")
         assert str(err.value) == "item not found"
 
 
@@ -38,4 +38,4 @@ async def test_http_error(aresponses):
     async with ClientSession() as session:
         api = API(TEST_API_TOKEN, session=session)
         with pytest.raises(RequestError):
-            await api.async_delete_bookmark("http://test.url")
+            await api.bookmark.async_delete_bookmark("http://test.url")


### PR DESCRIPTION
**Describe what the PR does:**

In anticipating of API endpoints for tags and notes, this PR moves bookmark API endpoints to their own object for better organization.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
