### PR TITLE
Make the library more compatible with type checkers

### DIFF
--- a/aiopinboard/__init__.py
+++ b/aiopinboard/__init__.py
@@ -1,2 +1,4 @@
 """Define the aiopinboard package."""
 from aiopinboard.api import API  # noqa
+
+__all__ = ["API"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Typing :: Typed",
+]
+include = [
+    "aiopinboard/py.typed"
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
While the library has lots of type hinting (yay! thanks!) it doesn't mark itself as being typed, so when it comes to running mypy over code that uses the library (for example) you get told things like this:

```
error: Skipping analyzing "aiopinboard": module is installed, but missing library stubs or py.typed marker  [import-untyped]
error: Skipping analyzing "aiopinboard.bookmark": module is installed, but missing library stubs or py.typed marker  [import-untyped]
Skipping analyzing "aiopinboard": module is installed, but missing library stubs or py.typed marker  [import-untyped]
note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

In passing, this PR also includes a line of code in `__init__.py` to "export" `API`.