### PR TITLE
Fix the saving of the description

### DIFF
--- a/aiopinboard/bookmark.py
+++ b/aiopinboard/bookmark.py
@@ -85,7 +85,7 @@ class BookmarkAPI:
         params: dict[str, Any] = {"url": url, "description": title}
 
         if description:
-            params["description"] = description
+            params["extended"] = description
         if tags:
             params["tags"] = tags
         if created_datetime:


### PR DESCRIPTION
At the API level, the title is called "description", and the description is called "extended". The library was placing the title in the API description (correct) and then overwriting it with the description, when it should have been placing it in "extended".
