### PR TITLE
ci: renovate use of `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,22 +80,16 @@ repos:
         language: system
         types: [text]
         entry: poetry run fix-byte-order-marker
-      - id: black
+      - id: format
         name: ☕️ Formatting code using ruff
         language: system
         types: [python]
         entry: poetry run ruff format
-      - id: isort
-        name: 🔀 Sorting all imports with isort
-        language: system
-        types: [python]
-        entry: poetry run isort
       - id: mypy
         name: 🆎 Performing static type checking using mypy
         language: system
         types: [python]
         entry: poetry run mypy
-        require_serial: true
       - id: no-commit-to-branch
         name: 🛑 Checking for commit to protected branch
         language: system
@@ -116,35 +110,17 @@ repos:
         language: system
         types: [python]
         entry: poetry run pylint
-      - id: pyupgrade
-        name: 🆙 Checking for upgradable syntax with pyupgrade
-        language: system
-        types: [python]
-        entry: poetry run pyupgrade
-        args: [--py39-plus, --keep-runtime-typing]
       - id: ruff
         name: 👔 Enforcing style guide with ruff
         language: system
         types: [python]
-        entry: poetry run ruff --fix
+        entry: poetry run ruff check --fix
       - id: trailing-whitespace
         name: ✄  Trimming trailing whitespace
         language: system
         types: [text]
         entry: poetry run trailing-whitespace-fixer
         stages: [commit, push, manual]
-      - id: vulture
-        name: 🔍 Finding unused Python code with Vulture
-        language: system
-        types: [python]
-        entry: poetry run vulture
-        pass_filenames: false
-        require_serial: true
-      - id: yamllint
-        name: 🎗  Checking YAML files with yamllint
-        language: system
-        types: [yaml]
-        entry: poetry run yamllint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.0-alpha.4"

--- a/aiopinboard/__init__.py
+++ b/aiopinboard/__init__.py
@@ -1,5 +1,5 @@
 """Define the aiopinboard package."""
 
-from aiopinboard.api import API  # noqa
+from aiopinboard.api import API
 
 __all__ = ["API"]

--- a/aiopinboard/api.py
+++ b/aiopinboard/api.py
@@ -34,8 +34,10 @@ class API:  # pylint: disable=too-few-public-methods
         """Initialize.
 
         Args:
+        ----
             api_token: A Pinboard API token.
             session: An optional aiohttp ClientSession.
+
         """
         self._api_token = api_token
         self._session = session
@@ -50,15 +52,19 @@ class API:  # pylint: disable=too-few-public-methods
         """Make a request to the API and return the XML response.
 
         Args:
+        ----
             method: An HTTP method.
             endpoint: A relative API endpoint.
             **kwargs: Additional kwargs to send with the request.
 
         Returns:
+        -------
             An API response payload.
 
         Raises:
+        ------
             RequestError: Raised upon an underlying HTTP error.
+
         """
         kwargs.setdefault("params", {})
         kwargs["params"]["auth_token"] = self._api_token

--- a/aiopinboard/bookmark.py
+++ b/aiopinboard/bookmark.py
@@ -28,14 +28,17 @@ class Bookmark:
     shared: bool
 
     @classmethod
-    def from_api_response(cls, data: dict[str, Any]) -> Bookmark:
+    def from_api_response(cls: type[Bookmark], data: dict[str, Any]) -> Bookmark:
         """Create a bookmark from an API response.
 
         Args:
+        ----
             data: The API response data.
 
         Returns:
+        -------
             A Bookmark object.
+
         """
         return Bookmark(
             data["hash"],
@@ -52,15 +55,17 @@ class Bookmark:
 class BookmarkAPI:
     """Define an API "manager" object."""
 
-    def __init__(self, async_request: Callable[..., Awaitable[ResponseType]]):
+    def __init__(self, async_request: Callable[..., Awaitable[ResponseType]]) -> None:
         """Initialize.
 
         Args:
+        ----
             async_request: The request method from the Client object.
+
         """
         self._async_request = async_request
 
-    async def async_add_bookmark(  # pylint: disable=too-many-arguments
+    async def async_add_bookmark(
         self,
         url: str,
         title: str,
@@ -75,6 +80,7 @@ class BookmarkAPI:
         """Add a new bookmark.
 
         Args:
+        ----
             url: The URL of the bookmark.
             title: The title of the bookmark.
             description: The optional description of the bookmark.
@@ -83,6 +89,7 @@ class BookmarkAPI:
             replace: Whether this should replace a bookmark with the same URL.
             shared: Whether this bookmark should be shared.
             toread: Whether this bookmark should be unread.
+
         """
         params: dict[str, Any] = {"url": url, "description": title}
 
@@ -103,11 +110,13 @@ class BookmarkAPI:
         """Delete a bookmark by URL.
 
         Args:
+        ----
             url: The URL of the bookmark to delete.
+
         """
         await self._async_request("get", "posts/delete", params={"url": url})
 
-    async def async_get_all_bookmarks(  # pylint: disable=too-many-arguments
+    async def async_get_all_bookmarks(
         self,
         *,
         tags: list[str] | None = None,
@@ -119,6 +128,7 @@ class BookmarkAPI:
         """Get recent bookmarks.
 
         Args:
+        ----
             tags: An optional list of tags to filter results by.
             start: The optional starting index to return (defaults to the start).
             results: The optional number of results (defaults to all).
@@ -126,7 +136,9 @@ class BookmarkAPI:
             to_dt: The optional datetime to end at.
 
         Returns:
+        -------
             A list of Bookmark objects.
+
         """
         params: dict[str, Any] = {"start": start}
 
@@ -148,10 +160,13 @@ class BookmarkAPI:
         """Get bookmark by a URL.
 
         Args:
+        ----
             url: The URL of the bookmark to get
 
         Returns:
+        -------
             A bookmark object (or None if no bookmark exists for the URL).
+
         """
         data = cast(
             DictType, await self._async_request("get", "posts/get", params={"url": url})
@@ -168,11 +183,14 @@ class BookmarkAPI:
         """Get bookmarks that were created on a specific date.
 
         Args:
+        ----
             bookmarked_on: The date to examine.
             tags: An optional list of tags to filter results by.
 
         Returns:
+        -------
             A list of Bookmark objects.
+
         """
         params: dict[str, Any] = {"dt": str(bookmarked_on)}
 
@@ -190,10 +208,13 @@ class BookmarkAPI:
         """Get a dictionary of dates and the number of bookmarks created on that date.
 
         Args:
+        ----
             tags: An optional list of tags to filter results by.
 
         Returns:
+        -------
             A dictionary of dates and the number of bookmarks for that date.
+
         """
         params: dict[str, Any] = {}
 
@@ -210,8 +231,10 @@ class BookmarkAPI:
     async def async_get_last_change_datetime(self) -> datetime:
         """Return the most recent time a bookmark was added, updated or deleted.
 
-        Returns:
+        Returns
+        -------
             A datetime object.
+
         """
         data = cast(DictType, await self._async_request("get", "posts/update"))
         parsed = arrow.get(data["update_time"])
@@ -226,11 +249,14 @@ class BookmarkAPI:
         """Get recent bookmarks.
 
         Args:
+        ----
             count: The number of bookmarks to return (max of 100).
             tags: An optional list of tags to filter results by.
 
         Returns:
+        -------
             A list of Bookmark objects.
+
         """
         params: dict[str, Any] = {"count": count}
 
@@ -246,10 +272,13 @@ class BookmarkAPI:
         """Return a dictionary of popular and recommended tags for a URL.
 
         Args:
+        ----
             url: The URL of the bookmark to delete.
 
         Returns:
+        -------
             A dictionary of tags.
+
         """
         data = cast(
             ListDictType,

--- a/aiopinboard/errors.py
+++ b/aiopinboard/errors.py
@@ -8,23 +8,22 @@ from aiopinboard.helpers.types import ResponseType
 class PinboardError(Exception):
     """Define a base Pinboard exception."""
 
-    pass
-
 
 class RequestError(PinboardError):
     """Define a exception related to HTTP request errors."""
-
-    pass
 
 
 def raise_on_response_error(data: ResponseType) -> None:
     """Raise an error if the data indicates that something went wrong.
 
     Args:
+    ----
         data: A response payload from the API.
 
     Raises:
+    ------
         RequestError: Raised upon any error from the API.
+
     """
     if isinstance(data, list):
         return

--- a/aiopinboard/helpers/__init__.py
+++ b/aiopinboard/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Define helpers."""

--- a/aiopinboard/note.py
+++ b/aiopinboard/note.py
@@ -13,7 +13,7 @@ from aiopinboard.helpers.types import DictType, ResponseType
 
 
 @dataclass
-class Note:  # pylint: disable=too-many-instance-attributes
+class Note:
     """Define a representation of a Pinboard note."""
 
     note_id: str
@@ -24,14 +24,17 @@ class Note:  # pylint: disable=too-many-instance-attributes
     length: int
 
     @classmethod
-    def from_api_response(cls, data: dict[str, Any]) -> Note:
+    def from_api_response(cls: type[Note], data: dict[str, Any]) -> Note:
         """Create a note from an API response.
 
         Args:
+        ----
             data: The API response data.
 
         Returns:
+        -------
             A Note object.
+
         """
         return cls(
             data["id"],
@@ -50,15 +53,19 @@ class NoteAPI:  # pylint: disable=too-few-public-methods
         """Initialize.
 
         Args:
+        ----
             async_request: The request method from the Client object.
+
         """
         self._async_request = async_request
 
     async def async_get_notes(self) -> list[Note]:
         """Get all notes.
 
-        Returns:
+        Returns
+        -------
             A list of Note objects.
+
         """
         data = cast(DictType, await self._async_request("get", "notes/list"))
         return [Note.from_api_response(note) for note in data["notes"]]

--- a/aiopinboard/tag.py
+++ b/aiopinboard/tag.py
@@ -15,7 +15,9 @@ class TagAPI:
         """Initialize.
 
         Args:
+        ----
             async_request: The request method from the Client object.
+
         """
         self._async_request = async_request
 
@@ -23,15 +25,19 @@ class TagAPI:
         """Delete a tag.
 
         Args:
+        ----
             tag: The tag to delete.
+
         """
         await self._async_request("get", "tags/delete", params={"tag": tag})
 
     async def async_get_tags(self) -> dict[str, int]:
         """Get a mapping of all tags in this account and how many times each is used.
 
-        Returns:
+        Returns
+        -------
             A dictionary of tags and usage count.
+
         """
         return cast(dict[str, int], await self._async_request("get", "tags/get"))
 
@@ -39,7 +45,9 @@ class TagAPI:
         """Rename a tag.
 
         Args:
+        ----
             old: The tag to rename.
             new: The new name.
+
         """
         await self._async_request("get", "tags/rename", params={"old": old, "new": new})

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Define examples."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -1399,20 +1399,6 @@ docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
-name = "vulture"
-version = "2.11"
-description = "Find dead code"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "vulture-2.11-py2.py3-none-any.whl", hash = "sha256:12d745f7710ffbf6aeb8279ba9068a24d4e52e8ed333b8b044035c9d6b823aba"},
-    {file = "vulture-2.11.tar.gz", hash = "sha256:f0fbb60bce6511aad87ee0736c502456737490a82d919a44e6d92262cb35f1c2"},
-]
-
-[package.dependencies]
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-
-[[package]]
 name = "yamllint"
 version = "1.35.1"
 description = "A linter for YAML files."
@@ -1536,4 +1522,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "610a78433761aba54003e1a228e67612820ceef38555bf022772ce3f0de2224b"
+content-hash = "3e081a9bfedc0672053247c02432b0660b0a197c9c014a398d56a9f67d8b758a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ pyupgrade = "^3.1.0"
 pyyaml = "^6.0.1"
 requests = ">=2.31.0"
 ruff = ">=0.0.261,<0.3.5"
-vulture = "^2.6"
 yamllint = "^1.28.0"
 
 [tool.poetry.urls]
@@ -99,6 +98,7 @@ yamllint = "^1.28.0"
 Changelog = "https://github.com/bachya/aiopinboard/releases"
 
 [tool.pylint.BASIC]
+class-const-naming-style = "any"
 expected-line-ending-format = "LF"
 
 [tool.pylint.DESIGN]
@@ -107,46 +107,306 @@ max-attributes = 20
 [tool.pylint.FORMAT]
 max-line-length = 88
 
-[tool.pylint.MASTER]
+[tool.pylint.MAIN]
+py-version = "3.12"
 ignore = [
-  "tests",
+    "tests",
 ]
+# Use a conservative default here; 2 should speed up most setups and not hurt
+# any too bad. Override on command line as appropriate.
+jobs = 2
+init-hook = """\
+    from pathlib import Path; \
+    import sys; \
+
+    from pylint.config import find_default_config_files; \
+
+    sys.path.append( \
+        str(Path(next(find_default_config_files())).parent.joinpath('pylint/plugins'))
+    ) \
+    """
 load-plugins = [
-  "pylint.extensions.bad_builtin",
-  "pylint.extensions.code_style",
-  "pylint.extensions.docparams",
-  "pylint.extensions.docstyle",
-  "pylint.extensions.empty_comment",
-  "pylint.extensions.overlapping_exceptions",
-  "pylint.extensions.typing",
+    "pylint.extensions.code_style",
+    "pylint.extensions.typing",
+]
+persistent = false
+fail-on = [
+    "I",
 ]
 
 [tool.pylint."MESSAGES CONTROL"]
-# Reasons disabled:
-# unnecessary-pass - This can hurt readability
 disable = [
-  "unnecessary-pass"
+    # These are subjective and should be left up to the developer:
+    "too-many-arguments",
+    "too-many-lines",
+    "too-many-locals",
+    "duplicate-code",
+
+    # Handled by ruff:
+    # Ref: <https://github.com/astral-sh/ruff/issues/970>
+    "anomalous-backslash-in-string",        # W605
+    "assert-on-string-literal",             # PLW0129
+    "assert-on-tuple",                      # F631
+    "await-outside-async",                  # PLE1142
+    "bad-classmethod-argument",             # N804
+    "bad-format-string",                    # W1302, F
+    "bad-format-string-key",                # W1300, F
+    "bad-str-strip-call",                   # PLE1310
+    "bad-string-format-type",               # PLE1307
+    "bare-except",                          # E722
+    "bidirectional-unicode",                # PLE2502
+    "binary-op-exception",                  # PLW0711
+    "broad-exception-caught",               # W0718
+    "cell-var-from-loop",                   # B023
+    "comparison-of-constants",              # PLR0133
+    "comparison-with-itself",               # PLR0124
+    "consider-alternative-union-syntax",    # UP007
+    "consider-iterating-dictionary",        # SIM118
+    "consider-merging-isinstance",          # PLR1701
+    "consider-using-alias",                 # UP006
+    "consider-using-dict-comprehension",    # C402
+    "consider-using-generator",             # C417
+    "consider-using-get",                   # SIM401
+    "consider-using-set-comprehension",     # C401
+    "consider-using-sys-exit",              # PLR1722
+    "consider-using-ternary",               # SIM108
+    "continue-in-finally",                  # PLE0116
+    "duplicate-bases",                      # PLE0241
+    "duplicate-except",                     # B014
+    "duplicate-key",                        # F601
+    "duplicate-string-formatting-argument", # F
+    "duplicate-value",                      # F
+    "empty-docstring",                      # D419
+    "eval-used",                            # S307
+    "exec-used",                            # S102
+    "expression-not-assigned",              # B018
+    "f-string-without-interpolation",       # F541
+    "forgotten-debug-statement",            # T100
+    "format-needs-mapping",                 # F502
+    "format-string-without-interpolation",  # F
+    "function-redefined",                   # F811
+    "global-variable-not-assigned",         # PLW0602
+    "implicit-str-concat",                  # ISC001
+    "import-self",                          # PLW0406
+    "inconsistent-quotes",                  # Q000
+    "invalid-all-object",                   # PLE0604
+    "invalid-character-backspace",          # PLE2510
+    "invalid-character-esc",                # PLE2513
+    "invalid-character-nul",                # PLE2514
+    "invalid-character-sub",                # PLE2512
+    "invalid-character-zero-width-space",   # PLE2515
+    "invalid-envvar-default",               # PLW1508
+    "invalid-name",                         # N815
+    "keyword-arg-before-vararg",            # B026
+    "line-too-long",                        # E501
+    "literal-comparison",                   # F632
+    "logging-format-interpolation",         # G
+    "logging-fstring-interpolation",        # G
+    "logging-not-lazy",                     # G
+    "logging-too-few-args",                 # PLE1206
+    "logging-too-many-args",                # PLE1205
+    "misplaced-future",                     # F404
+    "missing-class-docstring",              # D101
+    "missing-final-newline",                # W292
+    "missing-format-string-key",            # F524
+    "missing-function-docstring",           # D103
+    "missing-module-docstring",             # D100
+    "mixed-format-string",                  # F506
+    "multiple-imports",                     #E401
+    "named-expr-without-context",           # PLW0131
+    "nested-min-max",                       # PLW3301
+    "no-method-argument",                   # N805
+    "no-self-argument",                     # N805
+    "nonexistent-operator",                 # B002
+    "nonlocal-without-binding",             # PLE0117
+    "not-in-loop",                          # F701, F702
+    "notimplemented-raised",                # F901
+    "pointless-statement",                  # B018
+    "property-with-parameters",             # PLR0206
+    "raise-missing-from",                   # B904
+    "return-in-init",                       # PLE0101
+    "return-outside-function",              # F706
+    "singleton-comparison",                 # E711, E712
+    "subprocess-run-check",                 # PLW1510
+    "super-with-arguments",                 # UP008
+    "superfluous-parens",                   # UP034
+    "syntax-error",                         # E999
+    "too-few-format-args",                  # F524
+    "too-many-branches",                    # PLR0912
+    "too-many-format-args",                 # F522
+    "too-many-return-statements",           # PLR0911
+    "too-many-star-expressions",            # F622
+    "too-many-statements",                  # PLR0915
+    "trailing-comma-tuple",                 # COM818
+    "truncated-format-string",              # F501
+    "try-except-raise",                     # TRY302
+    "undefined-all-variable",               # F822
+    "undefined-variable",                   # F821
+    "ungrouped-imports",                    # I001
+    "unidiomatic-typecheck",                # E721
+    "unnecessary-comprehension",            # C416
+    "unnecessary-direct-lambda-call",       # PLC3002
+    "unnecessary-lambda-assignment",        # PLC3001
+    "unnecessary-pass",                     # PIE790
+    "unneeded-not",                         # SIM208
+    "unused-argument",                      # ARG001
+    "unused-format-string-argument",        # F507
+    "unused-format-string-key",             # F504
+    "unused-import",                        # F401
+    "unused-variable",                      # F841
+    "use-a-generator",                      # C417
+    "use-dict-literal",                     # C406
+    "use-list-literal",                     # C405
+    "used-prior-global-declaration",        # PLE0118
+    "useless-else-on-loop",                 # PLW0120
+    "useless-import-alias",                 # PLC0414
+    "useless-object-inheritance",           # UP004
+    "useless-return",                       # PLR1711
+    "wildcard-import",                      # F403
+    "wrong-import-order",                   # I001
+    "wrong-import-position",                # E402
+    "yield-inside-async-function",          # PLE1700
+    "yield-outside-function",               # F704
+
+    # Handled by mypy:
+    # Ref: <https://github.com/antonagestam/pylint-mypy-overlap>
+    "abstract-class-instantiated",
+    "arguments-differ",
+    "assigning-non-slot",
+    "assignment-from-no-return",
+    "assignment-from-none",
+    "bad-exception-cause",
+    "bad-format-character",
+    "bad-reversed-sequence",
+    "bad-super-call",
+    "bad-thread-instantiation",
+    "catching-non-exception",
+    "comparison-with-callable",
+    "deprecated-class",
+    "dict-iter-missing-items",
+    "format-combined-specification",
+    "global-variable-undefined",
+    "import-error",
+    "inconsistent-mro",
+    "inherit-non-class",
+    "init-is-generator",
+    "invalid-class-object",
+    "invalid-enum-extension",
+    "invalid-envvar-value",
+    "invalid-format-returned",
+    "invalid-hash-returned",
+    "invalid-metaclass",
+    "invalid-overridden-method",
+    "invalid-repr-returned",
+    "invalid-sequence-index",
+    "invalid-slice-index",
+    "invalid-slots",
+    "invalid-slots-object",
+    "invalid-star-assignment-target",
+    "invalid-str-returned",
+    "invalid-unary-operand-type",
+    "invalid-unicode-codec",
+    "isinstance-second-argument-not-valid-type",
+    "method-hidden",
+    "misplaced-format-function",
+    "missing-format-argument-key",
+    "missing-format-attribute",
+    "missing-kwoa",
+    "no-member",
+    "no-value-for-parameter",
+    "non-iterator-returned",
+    "non-str-assignment-to-dunder-name",
+    "nonlocal-and-global",
+    "not-a-mapping",
+    "not-an-iterable",
+    "not-async-context-manager",
+    "not-callable",
+    "not-context-manager",
+    "overridden-final-method",
+    "raising-bad-type",
+    "raising-non-exception",
+    "redundant-keyword-arg",
+    "relative-beyond-top-level",
+    "self-cls-assignment",
+    "signature-differs",
+    "star-needs-assignment-target",
+    "subclassed-final-class",
+    "super-without-brackets",
+    "too-many-function-args",
+    "typevar-double-variance",
+    "typevar-name-mismatch",
+    "unbalanced-dict-unpacking",
+    "unbalanced-tuple-unpacking",
+    "unexpected-keyword-arg",
+    "unhashable-member",
+    "unpacking-non-sequence",
+    "unsubscriptable-object",
+    "unsupported-assignment-operation",
+    "unsupported-binary-operation",
+    "unsupported-delete-operation",
+    "unsupported-membership-test",
+    "used-before-assignment",
+    "using-final-decorator-in-unsupported-version",
+    "wrong-exception-operation",
+]
+enable = [
+    "useless-suppression",
+    "use-symbolic-message-instead",
 ]
 
-[tool.pylint.REPORTS]
-score = false
+[tool.pylint.TYPING]
+runtime-typing = false
 
-[tool.pylint.SIMILARITIES]
-# Minimum lines number of a similarity.
-# We set this higher because of some cases where V2 and V3 functionality are
-# similar, but abstracting them isn't feasible.
-min-similarity-lines = 8
+[tool.pylint.CODE_STYLE]
+max-line-length-suggestions = 72
 
-# Ignore comments when computing similarities.
-ignore-comments = true
+[tool.ruff.lint]
+select = [
+    "ALL"
+]
 
-# Ignore docstrings when computing similarities.
-ignore-docstrings = true
+ignore = [
+    "ANN101",  # Missing type annotation for self
+    "D202",    # No blank lines allowed after function docstring
+    "D203",    # 1 blank line required before class docstring
+    "PLR0913", # This is subjective
+    "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+    "PT012",   # `pytest.raises()` block should contain a single simple statement
+    "TCH",     # flake8-type-checking
 
-# Ignore imports when computing similarities.
-ignore-imports = true
+    # May conflict with the formatter:
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "COM812",
+    "COM819",
+    "D206",
+    "D300",
+    "E111",
+    "E114",
+    "E117",
+    "ISC001",
+    "ISC002",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "W191",
+]
 
-[tool.vulture]
-min_confidence = 80
-paths = ["aiopinboard", "tests"]
-verbose = false
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = [
+    "aiopinboard",
+    "examples",
+    "tests",
+]
+combine-as-imports = true
+split-on-trailing-comma = false
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "ARG001",   # Tests ofen have unused arguments
+    "FBT001",   # Test fixtures may be boolean values
+    "PLR2004",  # Checking for magic values in tests isn't helpful
+    "S101",     # Assertions are fine in tests
+    "SLF001",   # We'll access a lot of private third-party members in tests
+]

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,6 @@
 """Define common test utilities."""
 
-import os
+from pathlib import Path
 
 TEST_API_TOKEN = "user:abcde12345"  # noqa: S105
 
@@ -9,11 +9,14 @@ def load_fixture(filename: str) -> str:
     """Load a fixture.
 
     Args:
+    ----
         filename: The filename of the fixtures/ file to load.
 
     Returns:
+    -------
         A string containing the contents of the file.
+
     """
-    path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
-    with open(path, encoding="utf-8") as fptr:
+    path = Path(f"{Path(__file__).parent}/fixtures/{filename}")
+    with Path.open(path, encoding="utf-8") as fptr:
         return fptr.read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Define dynamic test fixtures."""
 
+from __future__ import annotations
+
 import json
 from typing import Any, cast
 

--- a/tests/test_bookmark_api.py
+++ b/tests/test_bookmark_api.py
@@ -1,27 +1,31 @@
 """Test the API."""
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import aiohttp
+from aresponses import ResponsesMockServer
 import arrow
 import pytest
-from aresponses import ResponsesMockServer
 
 from aiopinboard import API
 from aiopinboard.bookmark import Bookmark
 from tests.common import TEST_API_TOKEN
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_add_bookmark(
     aresponses: ResponsesMockServer, posts_add_response: dict[str, Any]
 ) -> None:
     """Test deleting a bookmark.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_add_response: A fixture for a posts/add response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -42,22 +46,24 @@ async def test_add_bookmark(
             "My Test Bookmark",
             description="I like this bookmark",
             tags=["tag1", "tag2"],
-            created_datetime=datetime.now(),
+            created_datetime=datetime.now(tz=timezone.utc),
             replace=True,
             shared=True,
             toread=True,
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_delete_bookmark(
     aresponses: ResponsesMockServer, posts_delete_response: dict[str, Any]
 ) -> None:
     """Test deleting a bookmark.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_delete_response: A fixture for a posts/delete response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -76,15 +82,17 @@ async def test_delete_bookmark(
         await api.bookmark.async_delete_bookmark("http://test.url")
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_all_bookmarks(
     aresponses: ResponsesMockServer, posts_all_response: dict[str, Any]
 ) -> None:
     """Test getting recent bookmarks.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_all_response: A fixture for a posts/all response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -101,7 +109,7 @@ async def test_get_all_bookmarks(
         # Define a static datetime to test against:
         fixture_bookmark_date = datetime.strptime(
             "2020-09-02T03:59:55Z", "%Y-%m-%dT%H:%M:%SZ"
-        )
+        ).replace(tzinfo=timezone.utc)
         bookmarks = await api.bookmark.async_get_all_bookmarks(
             tags=["tag1"],
             start=2,
@@ -123,7 +131,7 @@ async def test_get_all_bookmarks(
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_bookmark_by_url(
     aresponses: ResponsesMockServer,
     posts_get_empty_response: dict[str, Any],
@@ -132,9 +140,11 @@ async def test_get_bookmark_by_url(
     """Test getting bookmarks by date.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_get_empty_response: A fixture for a posts/get response payload.
         posts_get_response: A fixture for a posts/get response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -174,7 +184,7 @@ async def test_get_bookmark_by_url(
         assert not bookmark
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_bookmarks_by_date(
     aresponses: ResponsesMockServer,
     posts_get_empty_response: dict[str, Any],
@@ -183,9 +193,11 @@ async def test_get_bookmarks_by_date(
     """Test getting bookmarks by date.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_get_empty_response: A fixture for a posts/get response payload.
         posts_get_response: A fixture for a posts/get response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -228,15 +240,17 @@ async def test_get_bookmarks_by_date(
         assert not bookmarks
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_dates(
     aresponses: ResponsesMockServer, posts_dates_response: dict[str, Any]
 ) -> None:
     """Test getting bookmarks by date.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_dates_response: A fixture for a posts/dates response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -258,15 +272,17 @@ async def test_get_dates(
         }
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_last_change_datetime(
     aresponses: ResponsesMockServer, posts_update_response: dict[str, Any]
 ) -> None:
     """Test getting the last time a bookmark was altered.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_update_response: A fixture for a posts/update response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -284,7 +300,7 @@ async def test_get_last_change_datetime(
         assert most_recent_dt == datetime(2020, 9, 3, 13, 7, 19, tzinfo=timezone.utc)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_last_change_datetime_no_session(
     aresponses: ResponsesMockServer, posts_update_response: dict[str, Any]
 ) -> None:
@@ -293,8 +309,10 @@ async def test_get_last_change_datetime_no_session(
     Note that this test also tests a created-on-the-fly aiohttp.ClientSession.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_update_response: A fixture for a posts/update response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -311,15 +329,17 @@ async def test_get_last_change_datetime_no_session(
     assert most_recent_dt == datetime(2020, 9, 3, 13, 7, 19, tzinfo=timezone.utc)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_recent_bookmarks(
     aresponses: ResponsesMockServer, posts_recent_response: dict[str, Any]
 ) -> None:
     """Test getting recent bookmarks.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_recent_response: A fixture for a posts/recent response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -349,15 +369,17 @@ async def test_get_recent_bookmarks(
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_suggested_tags(
     aresponses: ResponsesMockServer, posts_suggest_response: dict[str, Any]
 ) -> None:
     """Test getting recent bookmarks.
 
     Args:
+    ----
         aresponses: An aresponses server.
         posts_suggest_response: A fixture for a posts/suggest response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,25 +1,29 @@
 """Define tests for errors."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aiopinboard import API
 from aiopinboard.errors import RequestError
 from tests.common import TEST_API_TOKEN
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_data_error(
     aresponses: ResponsesMockServer, error_response: dict[str, Any]
 ) -> None:
     """Test that a Pinboard data error is handled properly.
 
     Args:
+    ----
         aresponses: An aresponses server.
         error_response: A Pinboard error response.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -37,12 +41,14 @@ async def test_data_error(
         assert str(err.value) == "item not found"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_http_error(aresponses: ResponsesMockServer) -> None:
     """Test that an HTTP error is handled properly.
 
     Args:
+    ----
         aresponses: An aresponses server.
+
     """
     aresponses.add(
         "api.pinboard.in",

--- a/tests/test_note_api.py
+++ b/tests/test_note_api.py
@@ -1,26 +1,30 @@
 """Test note API endpoints."""
 
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aiopinboard import API
 from aiopinboard.note import Note
 from tests.common import TEST_API_TOKEN
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_notes(
     aresponses: ResponsesMockServer, notes_get_response: dict[str, Any]
 ) -> None:
     """Test getting notes.
 
     Args:
+    ----
         aresponses: An aresponses server.
         notes_get_response: A notes get response.
+
     """
     aresponses.add(
         "api.pinboard.in",

--- a/tests/test_tag_api.py
+++ b/tests/test_tag_api.py
@@ -1,24 +1,28 @@
 """Test tag API endpoints."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aiopinboard import API
 from tests.common import TEST_API_TOKEN
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_delete_tag(
     aresponses: ResponsesMockServer, tags_delete_response: dict[str, Any]
 ) -> None:
     """Test deleting a tag.
 
     Args:
+    ----
         aresponses: An aresponses server.
         tags_delete_response: A fixture for a tags/delete response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -37,15 +41,17 @@ async def test_delete_tag(
         await api.tag.async_delete_tag("tag1")
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_tags(
     aresponses: ResponsesMockServer, tags_get_response: dict[str, Any]
 ) -> None:
     """Test getting tags.
 
     Args:
+    ----
         aresponses: An aresponses server.
         tags_get_response: A fixture for a tags/get response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",
@@ -63,15 +69,17 @@ async def test_get_tags(
         assert tags == {"tag1": 3, "tag2": 1, "tag3": 2}
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_rename_tag(
     aresponses: ResponsesMockServer, tags_rename_response: dict[str, Any]
 ) -> None:
     """Test renaming a tag.
 
     Args:
+    ----
         aresponses: An aresponses server.
         tags_rename_response: A fixture for a tags/rename response payload.
+
     """
     aresponses.add(
         "api.pinboard.in",


### PR DESCRIPTION
**Describe what the PR does:**

This PR uses more of `ruff`'s ruleset, which allows us to (a) be more conforming across the board, (b) eliminate redundant `pylint` and `mypy` checks, and (c) remove several redundant `pre-commit` hooks.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
